### PR TITLE
make web nodes able to be scaled up

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ You will need a Monero node. It is strongly advised for privacy reasons that you
 
 ## Installation
 ```bash
-docker pull snex00/xpg
 wget https://raw.githubusercontent.com/snex/xpg/master/docker-compose.yml
+wget https://raw.githubusercontent.com/snex/xpg/master/nginx.conf
 wget https://raw.githubusercontent.com/snex/xpg/master/.env.docker.example
 ```
 

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -63,12 +63,16 @@ class Wallet < ApplicationRecord
   end
 
   def running?
-    return false if pid.blank?
+    pid.present?
+  end
 
-    File.read("/proc/#{pid}/cmdline").match?(%r{monero-wallet-rpc.*--config-file=wallets/#{Rails.env}/#{name}.config})
+  def update_pid!
+    unless File.read("/proc/#{pid}/cmdline")
+               .match?(%r{monero-wallet-rpc.*--config-file=wallets/#{Rails.env}/#{name}.config})
+      update(pid: nil)
+    end
   rescue Errno::ENOENT
     update(pid: nil)
-    false
   end
 
   def run!

--- a/app/sidekiq/spawn_monero_rpc_wallets_job.rb
+++ b/app/sidekiq/spawn_monero_rpc_wallets_job.rb
@@ -4,8 +4,9 @@ class SpawnMoneroRpcWalletsJob
   include Sidekiq::Job
 
   def perform
-    Wallet.pluck(:id).each do |wallet_id|
-      MoneroRpcWalletJob.perform_async(wallet_id)
+    Wallet.all.each do |wallet|
+      wallet.update_pid!
+      MoneroRpcWalletJob.perform_async(wallet.id)
     end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,20 +24,54 @@ services:
     volumes:
       - redis:/data
 
-  web:
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      xpg:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+
+  sidekiq:
     image: snex00/xpg:latest
     volumes:
       - wallets:/app/wallets
-      - qr_codes:/app/storage
-    ports:
-      - "3000:3000"
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
-    extra_hosts:
-      - 'host.docker.internal:host-gateway'
+      xpg:
+        condition: service_healthy
+    command: ["bundle", "exec", "sidekiq", "-q", "default"]
+
+    # Since the monero RPC needs to be accessible on localhost, sidekiq scaling should only be done through
+    # the sidekiq concurrency option. You can only have ONE sidekiq container.
+    scale: 1
+    entrypoint: ''
+    env_file:
+      - '.env.docker'
+
+  xpg:
+    image: snex00/xpg:latest
+    volumes:
+      - qr_codes:/app/storage
+    healthcheck:
+      test: ["CMD", "curl", "-I", "HEAD", "http://localhost:3000"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: ["bundle", "exec", "puma", "-C", "config/puma.rb", "-p", "3000"]
+
+    # Feel free to scale this up to your heart's desire.
+    scale: 1
     env_file:
       - '.env.docker'
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+user  nginx;
+
+events {
+  worker_connections 1000;
+}
+http {
+  server {
+    listen 3000;
+    location / {
+      proxy_pass http://xpg:3000;
+    }
+  }
+}

--- a/spec/sidekiq/spawn_monero_rpc_wallets_job_spec.rb
+++ b/spec/sidekiq/spawn_monero_rpc_wallets_job_spec.rb
@@ -3,6 +3,17 @@
 RSpec.describe SpawnMoneroRpcWalletsJob, type: :job do
   let!(:wallet) { create(:wallet) }
 
+  before do
+    allow(Wallet).to receive(:all).and_return([wallet])
+    allow(wallet).to receive(:update_pid!)
+  end
+
+  it 'calls update_pid! on the wallet' do
+    described_class.new.perform
+
+    expect(wallet).to have_received(:update_pid!).once
+  end
+
   it 'enqueues a MoneroRpcWalletJob for the wallet' do
     described_class.new.perform
 


### PR DESCRIPTION
ensure that Wallet#running? is able to be called via web node that may not be running the monero-wallet-rpc proc, though we lose some visibility in cases where the proc crashes and we have to wait for it to be picked up again. Fixes #46 